### PR TITLE
perf: convert to text node data to string before convertion

### DIFF
--- a/src/updateNode.js
+++ b/src/updateNode.js
@@ -276,7 +276,12 @@ export default function updateNode (part, node, oldNode, context, forceUpdate, i
     return updateComponentNode(part, node, oldNode, context, forceUpdate, isSvgPart);
   } else if (isTagNode(node)) {
     return updateTagNode(part, node, oldNode, context, forceUpdate, isSvgPart);
-  } else if (isPrimitiveNode(node) && (node !== oldNode || forceUpdate)) {
-    return updateTextNode(part, node, oldNode);
+  } else if (isPrimitiveNode(node)) {
+    const isNodeDifferent = '' + node !== isPrimitiveNode(oldNode)? '' + oldNode: oldNode;
+    const shouldUpdate = isNodeDifferent || forceUpdate;
+
+    if(shouldUpdate) {
+      return updateTextNode(part, node, oldNode);
+    }    
   }
 }


### PR DESCRIPTION
converting __node__ to string prevents the update when node is '5'(string) and oldnode is 5(number)
```js
...
} else if (isPrimitiveNode(node) && ('' + node !== oldNode || forceUpdate)) {
    return updateTextNode(part, node, oldNode);
}
...
```